### PR TITLE
Consistent version numbers

### DIFF
--- a/.github/workflows/sync-version-with-upstream.yml
+++ b/.github/workflows/sync-version-with-upstream.yml
@@ -26,6 +26,6 @@ jobs:
           update-script: |
             VERSION=$(
               curl -sL https://api.github.com/repos/anchore/grype/releases | 
-              jq .  | grep tag_name | grep -v beta | head -n 1 | cut -d'"' -f4 | tr -d 'v'
+              jq .  | grep tag_name | grep -v beta | head -n 1 | cut -d'"' -f4
             )
             sed -i 's/^\(version: \).*$/\1'\"$VERSION\"'/' snap/snapcraft.yaml

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: grype
 base: core24
-version: "0.79.4"
+version: "v0.79.4"
 summary: Vulnerability scanner
 description: |
   CLI vulnerability scanner for container images and filesystems
@@ -31,11 +31,7 @@ confinement: classic
 parts:
   grype:
     plugin: go
-    source: https://github.com/anchore/$SNAPCRAFT_PROJECT_NAME/archive/refs/tags/v$SNAPCRAFT_PROJECT_VERSION.tar.gz
-    # This doesn't work due to https://github.com/canonical/craft-parts/issues/788
-    # so we pull the source tarball instead
-    #source: https://github.com/anchore/grype.git
-    #source-tag: $SNAPCRAFT_PROJECT_VERSION
+    source: https://github.com/anchore/$SNAPCRAFT_PROJECT_NAME/archive/refs/tags/$SNAPCRAFT_PROJECT_VERSION.tar.gz
     prime:
       - bin/grype
     build-snaps:


### PR DESCRIPTION
Updates the build action to ensure the version is in sync with upstream, preserving the 'v'.